### PR TITLE
Add missing s to install.packages in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ running ad-hoc analysis and exploratory visualizations.
 Usage
 -----
 
-    install.package('wethepeople')
+    install.packages('wethepeople')
 
     library(wethepeople)
     example(wethepeople)


### PR DESCRIPTION
The README was missing an 's' on install.packages.
